### PR TITLE
Add simple Node.js backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# circlenet
+# Circlenet
+
+This repository contains a simple example application with a Node.js backend and a static frontend served from the same project.
+
+## Requirements
+
+- Node.js 20+
+
+## Installation
+
+Install dependencies with npm:
+
+```bash
+npm install
+```
+
+## Running
+
+Start the server:
+
+```bash
+npm start
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser to see the frontend which fetches a message from the backend.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Circlenet</title>
+</head>
+<body>
+  <h1>Circlenet Frontend</h1>
+  <p id="message">Loading message...</p>
+
+  <script>
+    fetch('/api/message')
+      .then(res => res.json())
+      .then(data => {
+        document.getElementById('message').textContent = data.message;
+      })
+      .catch(err => {
+        document.getElementById('message').textContent = 'Error fetching message';
+        console.error(err);
+      });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "circlenet",
+  "version": "1.0.0",
+  "description": "Simple Express backend with static frontend",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from the frontend directory
+app.use(express.static(path.join(__dirname, 'frontend')));
+
+// API endpoint
+app.get('/api/message', (req, res) => {
+  res.json({ message: 'Hello from backend' });
+});
+
+// Fallback: serve index.html for any other routes
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js Express server and static frontend
- update README with setup and running instructions

## Testing
- `npm install --silent` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686507b4a7888332b23815bda8c77a26